### PR TITLE
Loosen the dependency version on psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-# Dev/Deployment
+g# Dev/Deployment
 tabulate==0.9.0
 pytest==7.2.1
 pytest-env==0.8.1
 pytest-cov==4.0.0
 coverage==7.2.1
-psycopg2-binary==2.9.5
+psycopg2-binary>=2.9.5
 mysql-connector-python==8.0.32
 pyyaml==6.0.1
 strip_ansi==0.1.1


### PR DESCRIPTION
I'd like to propose to loosen the psycopg2 dependency version to allow consumers of the library to upgrade it to a higher version without requiring a release of the pyway lib.